### PR TITLE
fix: Get nullable columns of basic types

### DIFF
--- a/internal/core/gen.go
+++ b/internal/core/gen.go
@@ -166,9 +166,6 @@ func jdbcGet(t ktType, idx int) string {
 	if t.IsInstant() {
 		return fmt.Sprintf(`results.getTimestamp(%d).toInstant()`, idx)
 	}
-	if t.IsBigDecimal() {
-		return fmt.Sprintf(`results.getBigDecimal(%d)`, idx)
-	}
 
 	var nullCast string
 	if t.IsNull {
@@ -364,10 +361,6 @@ func (t ktType) IsInstant() bool {
 
 func (t ktType) IsUUID() bool {
 	return t.Name == "UUID"
-}
-
-func (t ktType) IsBigDecimal() bool {
-	return t.Name == "java.math.BigDecimal"
 }
 
 func makeType(req *plugin.GenerateRequest, col *plugin.Column) ktType {

--- a/internal/core/gen.go
+++ b/internal/core/gen.go
@@ -175,7 +175,7 @@ func jdbcGet(t ktType, idx int) string {
 		nullCast = "?"
 	}
 
-	return fmt.Sprintf(`results.getObject(%d) as%s %s`, idx, nullCast, t.Name)
+	return fmt.Sprintf(`results.getObject(%d) as %s%s`, idx, t.Name, nullCast)
 }
 
 func (v QueryValue) ResultSet() string {

--- a/internal/core/gen.go
+++ b/internal/core/gen.go
@@ -166,17 +166,16 @@ func jdbcGet(t ktType, idx int) string {
 	if t.IsInstant() {
 		return fmt.Sprintf(`results.getTimestamp(%d).toInstant()`, idx)
 	}
-	if t.IsUUID() {
-		var nullCast string
-		if t.IsNull {
-			nullCast = "?"
-		}
-		return fmt.Sprintf(`results.getObject(%d) as%s %s`, idx, nullCast, t.Name)
-	}
 	if t.IsBigDecimal() {
 		return fmt.Sprintf(`results.getBigDecimal(%d)`, idx)
 	}
-	return fmt.Sprintf(`results.get%s(%d)`, t.Name, idx)
+
+	var nullCast string
+	if t.IsNull {
+		nullCast = "?"
+	}
+
+	return fmt.Sprintf(`results.getObject(%d) as%s %s`, idx, nullCast, t.Name)
 }
 
 func (v QueryValue) ResultSet() string {

--- a/internal/core/imports.go
+++ b/internal/core/imports.go
@@ -86,6 +86,9 @@ func (i *Importer) modelImports() [][]string {
 	if i.usesType("UUID") {
 		std["java.util.UUID"] = struct{}{}
 	}
+	if i.usesType("BigDecimal") {
+		std["java.math.BigDecimal"] = struct{}{}
+	}
 
 	stds := make([]string, 0, len(std))
 	for s := range std {
@@ -119,6 +122,9 @@ func stdImports(uses func(name string) bool) map[string]struct{} {
 	}
 	if uses("UUID") {
 		std["java.util.UUID"] = struct{}{}
+	}
+	if uses("BigDecimal") {
+		std["java.math.BigDecimal"] = struct{}{}
 	}
 
 	return std

--- a/internal/core/postgresql_type.go
+++ b/internal/core/postgresql_type.go
@@ -36,7 +36,7 @@ func postgresType(req *plugin.GenerateRequest, col *plugin.Column) (string, bool
 		return "Float", false
 
 	case "pg_catalog.numeric":
-		return "java.math.BigDecimal", false
+		return "BigDecimal", false
 
 	case "bool", "pg_catalog.bool":
 		return "Boolean", false


### PR DESCRIPTION
This pull request includes several changes to the `internal/core` package to simplify type handling and ensure proper import statements for `BigDecimal`. The most important changes include modifying the `jdbcGet` function, removing the `IsBigDecimal` method, and updating import handling functions.

Simplification of type handling:

* [`internal/core/gen.go`](diffhunk://#diff-ad587849b7360ae7e19ca42fa95ef15312c9aa9314ba511da66f928d99ab5ea0L169-R175): Modified the `jdbcGet` function to simplify and correct the handling of nullable types and removed the `IsBigDecimal` method as it is no longer needed. [[1]](diffhunk://#diff-ad587849b7360ae7e19ca42fa95ef15312c9aa9314ba511da66f928d99ab5ea0L169-R175) [[2]](diffhunk://#diff-ad587849b7360ae7e19ca42fa95ef15312c9aa9314ba511da66f928d99ab5ea0L370-L373)

Import handling improvements:

* [`internal/core/imports.go`](diffhunk://#diff-78532aa10e37c018f9abe8264da09dae6165db5a95b320a04864b5f573be1f1fR89-R91): Updated the `modelImports` and `stdImports` functions to include `BigDecimal` in the standard imports if used. [[1]](diffhunk://#diff-78532aa10e37c018f9abe8264da09dae6165db5a95b320a04864b5f573be1f1fR89-R91) [[2]](diffhunk://#diff-78532aa10e37c018f9abe8264da09dae6165db5a95b320a04864b5f573be1f1fR126-R128)

Type mapping correction:

* [`internal/core/postgresql_type.go`](diffhunk://#diff-881d27c6d9e8dbf781246bc6436c5308aedc07c39b536561ad00577134113942L39-R39): Changed the type mapping for `pg_catalog.numeric` to return `BigDecimal` instead of `java.math.BigDecimal` to ensure consistency.